### PR TITLE
BAH-849: Create checksum files only when import is success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 env/
 .idea
+.classpath
 .vscode/
 .project
 .settings/

--- a/generated-pom.xml
+++ b/generated-pom.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>net.mekomsolutions.odoo</groupId>
-  <artifactId>odoo_initializer</artifactId>
-  <version>1.0-SNAPSHOT</version>
-</project>

--- a/odoo_initializer/activator.py
+++ b/odoo_initializer/activator.py
@@ -1,4 +1,8 @@
 import logging
+import odoo
+from odoo import api
+
+from .utils import config
 
 from .models.country_loader import CountryLoader
 from .models.partner_loader import PartnerLoader
@@ -55,6 +59,8 @@ registered_loaders = [
 for registered_loader in registered_loaders:
     loader = registered_loader()
     loader.load_()
+
+    config.init = False
 
 
 _logger.info("initialization done")

--- a/odoo_initializer/models/language_loader.py
+++ b/odoo_initializer/models/language_loader.py
@@ -1,30 +1,28 @@
 import odoo
 from odoo import api
-from odoo.api import Environment
 from ..utils.config import config
 
-from .base_loader import BaseLoader, _logger
+from .base_loader import BaseLoader
 
 
 class LanguageLoader(BaseLoader):
     folder = "language"
-    model_name = "base.language.install"
+    model_name = "res.lang"
     allowed_file_extensions = ".xml"
     filters = {}
 
     def load_file(self, file_):
-
         if not file_:
             return []
         with api.Environment.manage():
-            registry = odoo.modules.registry.RegistryManager.get(config.db_name)
-            if not self.test:
-                registry.delete_all()
+            registry = odoo.registry(config.db_name)
             with registry.cursor() as cr:
+
                 uid = odoo.SUPERUSER_ID
-                env = Environment(cr, uid, {})
+                ctx = odoo.api.Environment(cr, uid, {})['res.users'].context_get()
+                env = odoo.api.Environment(cr, uid, ctx)
                 model = env[self.model_name]
+
                 for lang in file_:
-                    installer = model.create({'lang': lang.text})
-                    installer.lang_install()
+                    model.load_lang(lang.text)
         return

--- a/odoo_initializer/models/shop_mapping_loader.py
+++ b/odoo_initializer/models/shop_mapping_loader.py
@@ -2,6 +2,6 @@ from .base_loader import BaseLoader
 
 
 class ShopMappingLoader(BaseLoader):
-    model_name = "order.type.shop.mapping"
+    model_name = "order.type.shop.map"
     folder = "shop_mapping"
     filters = {}

--- a/odoo_initializer/tests/resources/config/odoo.conf
+++ b/odoo_initializer/tests/resources/config/odoo.conf
@@ -4,3 +4,4 @@ data_dir = /var/lib/odoo
 initializer_data_files_paths = /mnt/csv/openmrs_csv,/mnt/csv/odoo_csv
 initializer_checksums_path = /mnt/csv/checksums
 db_name = odoo
+without_demo = all

--- a/odoo_initializer/tests/test_data_files_utils.py
+++ b/odoo_initializer/tests/test_data_files_utils.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from os.path import dirname, basename
+from os.path import basename
 
 from odoo.tests import logging
 from odoo import tests
@@ -56,3 +56,20 @@ class TestDataFilesUtils(tests.BaseCase):
         files = data_files.get_files(basename(data_dir), ".csv")
         # Verify
         assert len(files) == 3
+
+    def test_create_checksum_when_file_loaded(self):
+        # Create config directories
+        temp_dir = tempfile.mkdtemp()
+        config_checksum_dir = tempfile.mkdtemp(dir=temp_dir)
+        config.checksum_folder = config_checksum_dir
+
+        file__ = data_files.get_checksum_path(self._get_test_file())
+        checksum = data_files.md5(self._get_test_file())
+
+        # Replay
+        file_processed = data_files.file_already_processed(self._get_test_file())
+        data_files.create_checksum_file(file__, checksum)
+
+        # Verify
+        assert not file_processed
+        assert os.path.exists(os.path.join(config_checksum_dir, "odoo/odoo.conf.checksum"))

--- a/odoo_initializer/tests/test_data_files_utils.py
+++ b/odoo_initializer/tests/test_data_files_utils.py
@@ -37,7 +37,7 @@ class TestDataFilesUtils(tests.BaseCase):
         # Verify
         assert checksum_path == "/custom/data_checksum/odoo/odoo.conf.checksum"
 
-    def test_get_files(self):
+    def test_get_files_should_get_files_by_extension(self):
         # Create config directories
 
         temp_dir = tempfile.mkdtemp()
@@ -54,8 +54,5 @@ class TestDataFilesUtils(tests.BaseCase):
 
         # Replay
         files = data_files.get_files(basename(data_dir), ".csv")
-        files_already_processed = data_files.get_files(basename(data_dir), ".csv")
-
         # Verify
         assert len(files) == 3
-        assert len(files_already_processed) == 0

--- a/odoo_initializer/utils/config.py
+++ b/odoo_initializer/utils/config.py
@@ -6,6 +6,7 @@ _logger = logging.getLogger(__name__)
 
 class Config:
     def __init__(self):
+        self.init = False
         try:
             data_files_paths_property = odoo.tools.config[
                 "initializer_data_files_paths"

--- a/odoo_initializer/utils/data_files_utils.py
+++ b/odoo_initializer/utils/data_files_utils.py
@@ -51,16 +51,16 @@ class DataFilesUtils:
                                 "Skipping already processed file: " + str(file_)
                             )
                             continue
-                        _logger.info(
-                                "processing file: " + str(file_)
-                            )
-                        with open(os.path.join(path, file_), "r") as file_data:
-                            if ".csv" in allowed_extensions:
-                                import_files.append(self.get_csv_content(file_data))
-                            elif ".xml" in allowed_extensions:
-                                xml_content = self.get_xml_content(file_data)
-                                import_files.append(xml_content)
+                        import_files.append(file_path)
+
         return import_files
+
+    def get_file_content(self, file_path, allowed_extensions):
+        with open(file_path, "r") as file_data:
+            if ".csv" in allowed_extensions:
+                return self.get_csv_content(file_data)
+            elif ".xml" in allowed_extensions:
+                return self.get_xml_content(file_data)
 
     @staticmethod
     def get_checksum_path(file_):
@@ -79,19 +79,19 @@ class DataFilesUtils:
         if os.path.exists(checksum_path):
             with open(checksum_path, "r") as f:
                 old_md5 = f.read()
-                if old_md5 != md5:
-                    f.close()
-                    with open(checksum_path, "w") as fw:
-                        fw.write(md5)
-            return old_md5 == md5
+                f.close()
+                return old_md5 == md5
         if not os.path.isdir(dirname(checksum_path)):
             try:
                 os.makedirs(dirname(checksum_path))
             except OSError:
                 raise
-        with open(checksum_path, "w") as f:
-            f.write(md5)
         return False
+
+    @staticmethod
+    def create_checksum_file(checksum_path, md5):
+        with open(checksum_path, "w") as fw:
+            fw.write(md5)
 
     @staticmethod
     def md5(fname):


### PR DESCRIPTION
https://bahmni.atlassian.net/browse/BAH-849

- Create checksum files only when the import process is successful
- Verify model existence from the database table instead of Environment
- Use the existing registry and not creating a new one, to fix the freeze issue after multiple initializations
- Enable Language loader to activate a language and load its resources