### PR TITLE
C2C-373: Load domain files alphabetically (based on file name) as default loading order.

### DIFF
--- a/odoo_initializer/utils/data_files_utils.py
+++ b/odoo_initializer/utils/data_files_utils.py
@@ -52,7 +52,7 @@ class DataFilesUtils:
                             continue
                         import_files.append(file_path)
 
-        return import_files
+        return sorted(import_files)
 
     def get_file_content(self, file_path, allowed_extensions):
         with open(file_path, "r") as file_data:


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/C2C-373

Issue: https://mekomsolutions.slack.com/archives/G421UNF5L/p1731939893305329?thread_ts=1731493086.511119&cid=G421UNF5L